### PR TITLE
Enforce unique OIB for organizers and increase upload limit

### DIFF
--- a/backend/assets/locales/en.json
+++ b/backend/assets/locales/en.json
@@ -193,5 +193,6 @@
   "2fa_verified_successfully": "2fa verified successfully",
   "key": "Key",
   "email_sent": "Email sent",
-  "failed_to_send_email": "Failed to send email"
+  "failed_to_send_email": "Failed to send email",
+  "oib_already_exists": "Oib already exists"
 }

--- a/backend/controllers/authUtil.js
+++ b/backend/controllers/authUtil.js
@@ -156,6 +156,23 @@ const registerUserUtility = async (req, res, options = {}) => {
       }
     }
 
+    // If organizer then check companyDetails.oib; it should be unique to every company
+    if (userType === "organizer" && companyDetails && companyDetails.oib) {
+      const query = { "companyDetails.oib": companyDetails.oib, "verificationStatus.email": "verified", "accountState.status": "active" };
+      if (existingUser) {
+        query._id = { $ne: existingUser._id };
+      }
+      const oibExists = await User.findOne(query);
+      if (oibExists) {
+        sendResponse({
+          res,
+          statusCode: 400,
+          translationKey: "oib_already_exists",
+        });
+        return { responseSent: true };
+      }
+    }
+
     // ✅ Create or reuse user
     let user = existingUser || new User();
     Object.assign(user, {

--- a/backend/controllers/uploadAzureController.js
+++ b/backend/controllers/uploadAzureController.js
@@ -10,7 +10,7 @@ const {
   StorageSharedKeyCredential,
 } = require("@azure/storage-blob");
 
-const MAX_FILE_SIZE = 3 * 1024 * 1024; // 3 MB
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
 
 // Initialize Azure Blob Service
 const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME;

--- a/backend/helperUtils/userResponseUtil.js
+++ b/backend/helperUtils/userResponseUtil.js
@@ -71,12 +71,12 @@ const formatUserResponse = (
   }
 
   // Include OTP info in dev only
-  if (process.env.NODE_ENV === "dev" && userObject.otpInfo && userObject.otpInfo.emailOtp.otp !== "") {
+  if ((process.env.NODE_ENV === "dev" || process.env.NODE_ENV === "prod") && userObject.otpInfo && userObject.otpInfo.emailOtp.otp !== "") {
     response.otpInfo = userObject.otpInfo;
   }
 
   // Include email verification info in dev only
-  if (process.env.NODE_ENV === "dev" && userObject.emailVerificationLink) {
+  if ((process.env.NODE_ENV === "dev" || process.env.NODE_ENV === "prod") && userObject.emailVerificationLink) {
     response.emailVerification = createVerificationLink(userObject.emailVerificationLink);
   }
 

--- a/backend/models/CompanyDetails.js
+++ b/backend/models/CompanyDetails.js
@@ -8,7 +8,6 @@ const CompanySchema = new mongoose.Schema(
     },
     oib: {
       type: String,
-      unique: true,
       trim: true,
     },
     bankAccountNumber: {


### PR DESCRIPTION
Added a check in user registration to ensure the OIB is unique among active, verified organizer accounts, and updated the English locale with a new error message. Increased the Azure upload file size limit to 100 MB. Also, adjusted user response utility to include OTP and email verification info in both dev and prod environments, and removed the unique constraint from the OIB field in the CompanyDetails schema.