### PR TITLE
Enhance user listing with role-based access control

### DIFF
--- a/backend/commonModules/usersManagement/usersController.js
+++ b/backend/commonModules/usersManagement/usersController.js
@@ -40,44 +40,120 @@ const createUser = async (req, res) => {
 const getUsers = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
   const { keyword, status, userType } = req.query;
+  const currentUser = req.user
 
-  try {
-    const { users, meta } = await usersService.getUsers({
-      page,
-      limit,
-      keyword,
-      status,
-      userType
-    });
-    // Ensure toJSON method is applied to strip out sensitive data
-const sanitizedUsers = users.map(user => {
-  // Use your updated toJSON (works for docs and plain objects)
-  let formattedUser = User.prototype.toJSON(user);
+  if (currentUser.userType === "admin") { // Admin can see all users
+    try {
+      const { users, meta } = await usersService.getAllUsers({
+        page,
+        limit,
+        keyword,
+        status,
+        userType
+      });
+      // Ensure toJSON method is applied to strip out sensitive data
+      const sanitizedUsers = users.map(user => {
+        // Use your updated toJSON (works for docs and plain objects)
+        let formattedUser = User.prototype.toJSON(user);
 
-  if (formattedUser.organizations && Array.isArray(formattedUser.organizations)) {
-    formattedUser.organizations = formattedUser.organizations.map(org => {
-      return Organizations.prototype.formatResponse(org);
-    });
+        if (formattedUser.organizations && Array.isArray(formattedUser.organizations)) {
+          formattedUser.organizations = formattedUser.organizations.map(org => {
+            return Organizations.prototype.formatResponse(org);
+          });
+        }
+
+        return formatUserResponse(formattedUser);
+      });
+
+      return sendResponse({
+        res,
+        statusCode: 200,
+        translationKey: "users_fetched_successfully",
+        data: sanitizedUsers,
+        meta
+      });
+    } catch (error) {
+      return sendResponse({
+        res,
+        statusCode: 500,
+        translationKey: "internal_server",
+        error,
+      });
+    }
+  } else if (["manager", "organizer"].includes(currentUser.userType)) { // Managers and Organizers can see users they created or users in their organizations
+    try {
+
+      //only staff, manager userTypes accepted
+
+      if (
+        !validateParams(req, res, {
+          enumFields: { userType: ["staff", "manager"] },
+        })
+      )
+        return;
+
+      // Managers and Organizers can only see users they created or users in their organizations
+      const { users, meta } = await usersService.getStaff({
+        page,
+        limit,
+        keyword,
+        status,
+        userType,
+        currentUser
+      });
+
+      // Filter users to only include those created by currentUser or in their organizations
+      const filteredUsers = users.filter(user => {
+        if (currentUser.userType === "organizer") {
+          // Organizer: users in orgs they created
+          return user.organizations?.some(
+            org => org.creator.toString() === currentUser._id.toString()
+          );
+        }
+
+        if (currentUser.userType === "manager") {
+          // Manager: users in orgs where they're listed in staff
+          return user.organizations?.some(
+            org => org.staff.some(
+              s => s.user.toString() === currentUser._id.toString()
+            )
+          );
+        }
+
+        return false;
+      });
+
+      // Ensure toJSON method is applied to strip out sensitive data
+      const sanitizedUsers = filteredUsers.map(user => {
+        // Use your updated toJSON (works for docs and plain objects)
+        let formattedUser = User.prototype.toJSON(user);
+
+        if (formattedUser.organizations && Array.isArray(formattedUser.organizations)) {
+          formattedUser.organizations = formattedUser.organizations.map(org => {
+            return Organizations.prototype.formatResponse(org);
+          });
+        }
+
+        return formatUserResponse(formattedUser);
+      });
+
+      return sendResponse({
+        res,
+        statusCode: 200,
+        translationKey: "users_fetched_successfully",
+        data: sanitizedUsers,
+        meta
+      });
+    } catch (error) {
+      return sendResponse({
+        res,
+        statusCode: 500,
+        translationKey: "internal_server",
+        error,
+      });
+    }
   }
 
-  return formatUserResponse(formattedUser);
-});
-
-    return sendResponse({
-      res,
-      statusCode: 200,
-      translationKey: "users_fetched_successfully",
-      data: sanitizedUsers,
-      meta
-    });
-  } catch (error) {
-    return sendResponse({
-      res,
-      statusCode: 500,
-      translationKey: "internal_server",
-      error,
-    });
-  }
 };
 
 

--- a/backend/commonModules/usersManagement/usersRepository.js
+++ b/backend/commonModules/usersManagement/usersRepository.js
@@ -70,6 +70,50 @@ const getUsersWithFilters = async (query, skip, limit) => {
   return users;
 };
 
+//Get all staff and managers with filters
+const getStaffWithFilters = async (query, skip, limit) => {
+  return User.aggregate([
+    { $match: query },
+    { $sort: { createdAt: -1 } },
+    { $skip: skip },
+    ...(limit > 0 ? [{ $limit: limit }] : []),
+
+    // Lookup organizations the user belongs to (as creator or staff)
+    {
+      $lookup: {
+        from: "organizations",
+        let: { userId: "$_id" },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $or: [
+                  { $eq: ["$creator", "$$userId"] },
+                  { $in: ["$$userId", "$staff.user"] },
+                ],
+              },
+              status: { $ne: "deleted" },
+            },
+          },
+          { $project: { basicInfo: 1, staff: 1, creator: 1 } },
+        ],
+        as: "organizations",
+      },
+    },
+
+    // Lookup suppliers if needed
+    {
+      $lookup: {
+        from: "suppliers",
+        localField: "companyDetails.suppliers",
+        foreignField: "_id",
+        as: "companyDetails.suppliers",
+      },
+    },
+  ]);
+};
+
+
 
 // Count by condition
 const countUsers = async (query = {}) => {
@@ -108,6 +152,7 @@ const updateTwoFA = async (userId, data) => {
 module.exports = {
   createUser,
   getUsersWithFilters,
+  getStaffWithFilters,
   countUsers,
   findUserById,
   updateUserData,

--- a/backend/commonModules/usersManagement/usersRoutes.js
+++ b/backend/commonModules/usersManagement/usersRoutes.js
@@ -36,7 +36,7 @@ router.post("/", roleMiddleware(["admin", "organizer", "manager"]), apiRateLimit
 router.get("/:id", apiRateLimiterUserDetail, getUserDetails);
 
 // Get all users with pagination
-router.get("/", apiRateLimiterUsers, getUsers);
+router.get("/", apiRateLimiterUsers, roleMiddleware(["admin", "organizer", "manager"]), getUsers);
 
 // Update an existing user
 router.put("/:id", apiRateLimiterUserUpdate, updateUser);

--- a/backend/commonModules/usersManagement/usersService.js
+++ b/backend/commonModules/usersManagement/usersService.js
@@ -12,7 +12,7 @@ const { buildKeywordQueryFromModel } = require("../../helperUtils/queryUtil");
 
 const APP_NAME = "Pleis App";
 
-const getUsers = async ({ page, limit, keyword, status, userType }) => {
+const getAllUsers = async ({ page, limit, keyword, status, userType }) => {
   const query = {
     "verificationStatus.email": "verified",
   };
@@ -53,6 +53,58 @@ const getUsers = async ({ page, limit, keyword, status, userType }) => {
     meta,
   };
 };
+
+//to get only staff and managers
+const getStaff = async ({ page, limit, keyword, status, userType, currentUser }) => {
+  const query = {
+    "verificationStatus.email": "verified",
+    "accountState.status": status || { $ne: "deleted" },
+  };
+
+  if (keyword && keyword.trim() !== "") {
+    Object.assign(query, buildKeywordQueryFromModel(User, keyword));
+  }
+
+  if (userType !== undefined) {
+    query["accountState.userType"] = userType;
+  }
+
+  const skip = (page - 1) * limit;
+
+  if (currentUser.userType === "manager") {
+    const orgs = await Organizations.find({
+      "staff.user": currentUser._id,
+      status: { $ne: "deleted" },
+    }).select("staff.user");
+    
+
+    const allowedUserIds = orgs.flatMap(org => org.staff.map(s => s.user));
+    query["_id"] = { $in: allowedUserIds };
+
+  } else if (currentUser.userType === "organizer") {
+    const orgs = await Organizations.find({
+      creator: currentUser._id,
+      status: { $ne: "deleted" },
+    }).select("staff.user creator");
+
+
+    const allowedUserIds = orgs.flatMap(org => [org.creator, ...org.staff.map(s => s.user)]);
+    query["_id"] = { $in: allowedUserIds };
+  }
+
+  const [users, totalFiltered] = await Promise.all([
+    userRepo.getStaffWithFilters(query, skip, limit),
+    userRepo.countUsers(query),
+  ]);
+
+  const meta = {
+    ...generateMeta(page, limit, totalFiltered),
+  };
+
+  return { users, meta };
+};
+
+
 
 
 const updateUser = async (req, res, options = {}) => {
@@ -308,7 +360,8 @@ const disableTwoFA = async (userId) => {
 
 
 module.exports = {
-  getUsers,
+  getAllUsers,
+  getStaff,
   updateUser,
   deleteUser,
   getUserDetails,

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -239,11 +239,11 @@ const login = async (req, res) => {
       data: response,
     });
   } catch (error) {
-    console.log("error:", error);
     return sendResponse({
       res,
       statusCode: 400,
       translationKey: error,
+      error,
     });
   }
 };

--- a/backend/controllers/authUtil.js
+++ b/backend/controllers/authUtil.js
@@ -248,7 +248,8 @@ const registerUserUtility = async (req, res, options = {}) => {
 
     await session.commitTransaction();
 
-    const userObject = user.toJSON(user);
+    const userObject = user.toJSON();
+    console.log("userObject-->", userObject);
     const formattedResponse = formatUserResponse(userObject);
 
     return { success: true, user: formattedResponse, responseSent: false };


### PR DESCRIPTION
Updated user listing logic to enforce role-based access: admins can view all users, while managers and organizers can only view users they created or users in their organizations. Added new repository and service methods to support filtered staff queries, updated route middleware for access control, and improved error handling and response formatting.