### PR TITLE
Move tag keyword filtering to service

### DIFF
--- a/backend/admin/tags/tagsRepository.js
+++ b/backend/admin/tags/tagsRepository.js
@@ -21,26 +21,14 @@ const createTag = async (data) => {
 /**
  * ADMIN LISTING (no cache)
  */
-const getTagsWithFilters = async (query, skip, limit, keyword) => {
+const getTagsWithFilters = async (query, skip, limit) => {
   const tagsQuery = Tags.find(query)
     .populate("type", "title") // Populate the 'type' field with the 'title' field
     .sort({ createdAt: -1 })
     .skip(skip)
     .limit(limit);
 
-  const tags = await tagsQuery.exec();
-
-  // If keyword is provided, filter by both tag.title and type.title
-  if (keyword) {
-    const keywordRegex = new RegExp(keyword, 'i'); // Create a case-insensitive regex for keyword
-
-    return tags.filter(tag =>
-      (tag.title && keywordRegex.test(tag.title)) || // Check tag.title
-      (tag.type && tag.type.title && keywordRegex.test(tag.type.title)) // Check type.title if populated
-    );
-  }
-
-  return tags;
+  return tagsQuery.exec();
 };
 
 /**

--- a/backend/admin/tags/tagsService.js
+++ b/backend/admin/tags/tagsService.js
@@ -25,6 +25,27 @@ const getTags = async ({ page, limit, keyword, type, status, date }) => {
     filters.push({ status: { $ne: "deleted" } });
   }
 
+  if (type) {
+    filters.push({ type });
+  }
+
+  if (keyword) {
+    const keywordRegex = new RegExp(keyword, "i");
+    const matchingTagTypes = await TagTypesModel.find({
+      title: { $regex: keywordRegex },
+      status: { $ne: "deleted" },
+    }).select("_id");
+
+    const matchingTypeIds = matchingTagTypes.map((tagType) => tagType._id);
+
+    filters.push({
+      $or: [
+        { title: { $regex: keywordRegex } },
+        ...(matchingTypeIds.length ? [{ type: { $in: matchingTypeIds } }] : []),
+      ],
+    });
+  }
+
 
 
   const query = filters.length ? { $and: filters } : {};
@@ -33,7 +54,7 @@ const getTags = async ({ page, limit, keyword, type, status, date }) => {
 
   // Fetch tags and related counts
   const [tags, totalFiltered, total, active, inactive] = await Promise.all([
-    tagRepo.getTagsWithFilters(query, skip, limit === 0 ? 0 : limit,keyword),
+    tagRepo.getTagsWithFilters(query, skip, limit === 0 ? 0 : limit),
     tagRepo.countTags(query),
     tagRepo.countTags({ status: { $ne: "deleted" } }),
     tagRepo.countTags({ status: "active" }),

--- a/backend/commonModules/paymentsIntegrations/monri/monriController.js
+++ b/backend/commonModules/paymentsIntegrations/monri/monriController.js
@@ -6,6 +6,26 @@ const monriRepository = require("./monriRepository");
 const { verifyTransaction, createTransactionMonriOrder } = require("./monriService");
 const { UserBillingInformation } = require("../../transactions/UserBillingInformation");
 
+const FORCE_MONRI_TEST_ENV = true;
+
+function isMonriProduction() {
+  if (FORCE_MONRI_TEST_ENV) return false;
+
+  return ["prod", "production"].includes(
+    String(process.env.NODE_ENV || "").toLowerCase()
+  );
+}
+
+function getMonriBaseUrl() {
+  return isMonriProduction()
+    ? "https://ipg.monri.com"
+    : "https://ipgtest.monri.com";
+}
+
+function getMonriComponentsEnv() {
+  return isMonriProduction() ? "prod" : "test";
+}
+
 /**
  * digest = SHA512(key + order_number + amount + currency)
  */
@@ -47,7 +67,7 @@ exports.redirectToMonriWebPay = async (req, res) => {
   <body onload="document.forms[0].submit()">
     <p>Redirecting to secure payment...</p>
 
-    <form method="POST" action="https://ipgtest.monri.com/v2/form">
+    <form method="POST" action="${getMonriBaseUrl()}/v2/form">
       <input type="hidden" name="authenticity_token" value="${process.env.MONRI_AUTH_TOKEN}" />
       <input type="hidden" name="transaction_type" value="purchase" />
 
@@ -104,7 +124,7 @@ exports.redirectToMonriWalletPay = async (req, res) => {
     const authorization = buildAuthorizationHeader({ body });
 
     const response = await axios.post(
-      "https://ipgtest.monri.com/v2/payment/new",
+      `${getMonriBaseUrl()}/v2/payment/new`,
       body,
       {
         headers: {
@@ -122,7 +142,7 @@ exports.redirectToMonriWalletPay = async (req, res) => {
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<script src="https://ipgtest.monri.com/dist/components.js"></script>
+<script src="${getMonriBaseUrl()}/dist/components.js"></script>
 
 <style>
 body {
@@ -164,7 +184,7 @@ button {
 <script>
 
 const monri = Monri("${process.env.MONRI_AUTH_TOKEN}", {
-  environment: "test"
+  environment: "${getMonriComponentsEnv()}"
 });
 
 const components = monri.components({
@@ -207,7 +227,7 @@ document.getElementById("payBtn").onclick = async function() {
 
 const applePay = components.create("apple-pay", {
   trx_token: "${trxToken}",
-  environment: "test",
+  environment: "${getMonriComponentsEnv()}",
   transaction: {
     ch_full_name: "Test User",
     address: "Street 1",
@@ -230,7 +250,7 @@ applePay.mount("apple-pay");
 
 const googlePay = components.create("google-pay", {
   trx_token: "${trxToken}",
-  environment: "test",
+  environment: "${getMonriComponentsEnv()}",
   countryCode: "HR",
   currencyCode: "EUR"
 });
@@ -412,7 +432,7 @@ exports.createClientSecret = async (req, res) => {
     const authorization = buildAuthorizationHeader({ body });
 
     const response = await axios.post(
-      "https://ipgtest.monri.com/v2/payment/new",
+      `${getMonriBaseUrl()}/v2/payment/new`,
       body,
       {
         headers: {
@@ -508,9 +528,7 @@ exports.createWebPaySession = async (req, res) => {
     const authorization = buildAuthorizationHeader({ body });
 
     const monriApiResponse = await axios.post(
-      process.env.NODE_ENV === "prod"
-        ? "https://ipg.monri.com/v2/payment/new"
-        : "https://ipgtest.monri.com/v2/payment/new",
+      `${getMonriBaseUrl()}/v2/payment/new`,
       body,
       {
         headers: {
@@ -544,7 +562,7 @@ exports.createWebPaySession = async (req, res) => {
       language: "en",
     };
 
-    const environment = process.env.NODE_ENV === "prod" ? "prod" : "test";
+    const environment = getMonriComponentsEnv();
 
     const response = {
       authenticity_token: process.env.MONRI_AUTH_TOKEN,
@@ -636,7 +654,7 @@ async function refundViaMonri({
   };
 
   const response = await axios.post(
-    "https://ipgtest.monri.com/v2/payment/refund",
+    `${getMonriBaseUrl()}/v2/payment/refund`,
     payload,
     {
       headers: {


### PR DESCRIPTION
Tags: Remove keyword-based filtering from tagsRepository (drop keyword param) and handle keyword/type filtering in tagsService instead. The service now looks up TagTypes matching the keyword and adds an $or clause to match tag.title or tag.type IDs, and also supports filtering by type.

Monri: Centralize Monri environment/URL selection by adding helper functions (isMonriProduction, getMonriBaseUrl, getMonriComponentsEnv) and a FORCE_MONRI_TEST_ENV flag. Replace hardcoded test/prod URLs and environment strings with these helpers across Monri controllers (redirects, wallet/pay, client secret, web pay session, refunds), so the base URL and components environment are chosen consistently (forced to test while FORCE_MONRI_TEST_ENV is true).