### PR TITLE
Sort populated tags/categories; add reward lookup

### DIFF
--- a/backend/admin/events/eventRepository.js
+++ b/backend/admin/events/eventRepository.js
@@ -118,8 +118,8 @@ const findEventById = async (id) => {
         select: "title",
       },
     })
-    .populate("basicInfo.categories", "title image otherInfo")
-    .populate("basicInfo.tags", "title otherInfo")
+    .populate({ path: "basicInfo.categories", select: "title image otherInfo", options: { sort: { title: 1 } } })
+    .populate({ path: "basicInfo.tags", select: "title otherInfo", options: { sort: { title: 1 } } })
     .populate({
       path: "basicInfo.organization",
       select:

--- a/backend/admin/organizations/organizationRepository.js
+++ b/backend/admin/organizations/organizationRepository.js
@@ -205,8 +205,8 @@ const getOrganizationDetails = async (id) => {
 
   const [organization, primaryVenue, events, ticketsSold, views, revenue, clubMembersCount] = await Promise.all([
     Organizations.findById(id)
-      .populate("otherInfo.tags")
-      .populate("otherInfo.categories")
+      .populate({ path: "otherInfo.tags", options: { sort: { title: 1 } } })
+      .populate({ path: "otherInfo.categories", options: { sort: { title: 1 } } })
       .populate({
         path: "creator",
         select: "firstName lastName email companyDetails",

--- a/backend/app/bookings/ticketings/ticketingBookingRepository.js
+++ b/backend/app/bookings/ticketings/ticketingBookingRepository.js
@@ -143,6 +143,7 @@ const getTicketingBookingById = async (id) => {
               createdAt: 1,
               isFastTrack: 1,
               pricingPhase: 1,
+              meta: 1,
             },
           },
         ],
@@ -222,7 +223,32 @@ const getTicketingBookingById = async (id) => {
     { $project: { ticketEvent: 0 } },
   ]);
 
-  return result[0] || null;
+  let resultItem = result[0] || null;
+
+  if (resultItem) {
+    const orderMeta = resultItem.order?.meta;
+
+    switch (orderMeta?.type) {
+      case "rewards": {
+        // Only build ObjectId when valid to avoid runtime crashes.
+        if (mongoose.Types.ObjectId.isValid(orderMeta?.id)) {
+          const rewardDetails = await mongoose.connection.collection("rewards").findOne(
+            { _id: new mongoose.Types.ObjectId(orderMeta.id) },
+            { projection: { _id: 1, title: 1, minPointsRequiredToClaim: 1 } }
+          );
+          resultItem.order.rewardDetails = rewardDetails;
+        } else {
+          resultItem.order.rewardDetails = null;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+
+  return resultItem;
 };
 
 

--- a/backend/app/events/eventRepository.js
+++ b/backend/app/events/eventRepository.js
@@ -84,8 +84,8 @@ const countEvents = async (query = {}) => {
 const findEventById = async (id) => {
   return Events.findById(id)
     .populate("basicInfo.venue", "title location floorPlan")
-    .populate("basicInfo.categories", "title image otherInfo")
-    .populate("basicInfo.tags", "title otherInfo")
+    .populate({ path: "basicInfo.categories", select: "title image otherInfo", options: { sort: { title: 1 } } })
+    .populate({ path: "basicInfo.tags", select: "title otherInfo", options: { sort: { title: 1 } } })
     .populate({
       path: "basicInfo.organization",
       select: "basicInfo otherInfo operatingHours location",
@@ -93,10 +93,12 @@ const findEventById = async (id) => {
         {
           path: "otherInfo.categories",
           select: "title image otherInfo",
+          options: { sort: { title: 1 } },
         },
         {
           path: "otherInfo.tags",
           select: "title otherInfo",
+          options: { sort: { title: 1 } },
         },
       ],
     })

--- a/backend/organizer/organizations/organizationController.js
+++ b/backend/organizer/organizations/organizationController.js
@@ -333,7 +333,7 @@ const getOrganizationDetails = async (req, res) => {
     })
   )
     return;
-  const organization = await organizationService.getOrganizationDetails(id);
+  const organization = await organizationService.findOrganizationById(id);
   if (!organization) {
     return sendResponse({
       res,


### PR DESCRIPTION
Add deterministic sorting for populated category/tag relations by passing populate options (sort by title) in admin and app event and organization repositories. Include meta in ticketing booking projection and implement a rewards lookup: when order.meta.type === 'rewards' and the id is a valid ObjectId, fetch reward details (id, title, minPointsRequiredToClaim) from the rewards collection and attach to result.order.rewardDetails; otherwise set null. Also update organizer controller to call findOrganizationById instead of getOrganizationDetails.