### PR TITLE
Add FeedConfig and improve categories/events handling

### DIFF
--- a/backend/admin/categories/Categories.js
+++ b/backend/admin/categories/Categories.js
@@ -17,10 +17,6 @@ const categoriesSchema = new mongoose.Schema(
       enum: ["active", "inactive", "deleted"],
       default: "active",
     },
-    quickAction: {
-      type: Boolean,
-      default: true,
-    },
     order: {
       type: Number,
       default: 0,

--- a/backend/admin/categories/categoriesController.js
+++ b/backend/admin/categories/categoriesController.js
@@ -18,7 +18,6 @@ const createCategory = async (req, res) => {
       image,
       title,
       status: "active",
-      quickAction: true, // Set quickAction to true by default for new categories
     });
 
     return sendResponse({
@@ -114,7 +113,7 @@ const getPublicCategories = async (req, res) => {
 
 const updateCategory = async (req, res) => {
   const { id } = req.params;
-  const { title, status, image, quickAction } = req.body;
+  const { title, status, image } = req.body;
 
   if (
     !validateParams(req, res, {
@@ -129,7 +128,6 @@ const updateCategory = async (req, res) => {
       title,
       status,
       image,
-      quickAction,
     });
 
     if (!updated) {

--- a/backend/admin/categories/categoriesRepository.js
+++ b/backend/admin/categories/categoriesRepository.js
@@ -54,11 +54,16 @@ const getCategoriesWithFilters = async (
  * ============================
  */
 const getPublicActiveCategories = async (filter = {}) => {
-      return Categories.find({ status: "active", ...filter })
+  return cache({
+    namespace: "categories:public",
+    ttl: null,
+    fetchFn: () =>
+      Categories.find({ status: "active", ...filter })
         .sort({ order: 1 })
         .select("title image order")
-        .lean();
-    }
+        .lean(),
+  });
+};
 
     
 

--- a/backend/admin/categories/categoriesService.js
+++ b/backend/admin/categories/categoriesService.js
@@ -6,8 +6,8 @@ const mongoose = require("mongoose");
 const { formatCategories } = require("./formatters/categoryFormatter");
 const { cache, invalidate } = require("@redisCache");
 
-const createCategory = async ({ image, title, status, quickAction }) => {
-  return await categoryRepo.createCategory({ image, title, status, quickAction });
+const createCategory = async ({ image, title, status }) => {
+  return await categoryRepo.createCategory({ image, title, status });
 };
 const getCategories = async ({ page, limit, keyword, status, date, orderSort = "asc" }) => {
   const query = {};
@@ -92,7 +92,6 @@ const updateCategory = async (id, data) => {
     ...(data.title !== undefined && { title: data.title }),
     ...(data.image !== undefined && { image: data.image }),
     ...(data.status !== undefined && { status: data.status }),
-    ...(data.quickAction !== undefined && { quickAction: data.quickAction }),
   };
 
   if (Object.keys(updateData).length === 0) {

--- a/backend/admin/events/eventController.js
+++ b/backend/admin/events/eventController.js
@@ -6,6 +6,7 @@ const {
   getReadableErrorMessage,
   convertTimezoneToUtc,
   isValidNanoid,
+  uniqueObjectIds,
 } = require("../../helperUtils/responseUtil");
 const { getVenueDetails } = require("../venues/venuesService");
 const mongoose = require('mongoose');
@@ -225,8 +226,13 @@ const createEvent = async (req, res) => {
       organization: basicInfo.organization,
       venue: basicInfo.venue,
       venueLocation: venueItem.location,
-      categories: Array.isArray(basicInfo.categories) ? basicInfo.categories : [],
-      tags: Array.isArray(basicInfo.tags) ? basicInfo.tags : [],
+      categories: Array.isArray(basicInfo.categories)
+        ? uniqueObjectIds(basicInfo.categories)
+        : [],
+
+      tags: Array.isArray(basicInfo.tags)
+        ? uniqueObjectIds(basicInfo.tags)
+        : [],
       partnerOrganization: basicInfo.partnerOrganization || null,
     },
     schedule: {
@@ -304,9 +310,9 @@ const createEvent = async (req, res) => {
 
 const getEvents = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
-  let { keyword, status = "active", startDate, endDate, organization,companyOrganizer } = req.query;
+  let { keyword, status = "active", startDate, endDate, organization, companyOrganizer } = req.query;
   const { _id, timezone } = req.user;
-  if(req.user.userType === "organizer"){
+  if (req.user.userType === "organizer") {
     companyOrganizer = req.user._id;
   }
 

--- a/backend/admin/events/eventRepository.js
+++ b/backend/admin/events/eventRepository.js
@@ -18,10 +18,10 @@ const createEvent = async (data, ticketingData) => {
 
   const companyOrganizer = await getOrgCompanyOrganizer(data.basicInfo.organization)
   data.companyOrganizer = companyOrganizer
-if (ticketingData) {
-  ticketingData.companyOrganizer = companyOrganizer
-  ticketingData.organization = data.basicInfo.organization
-}
+  if (ticketingData) {
+    ticketingData.companyOrganizer = companyOrganizer
+    ticketingData.organization = data.basicInfo.organization
+  }
   // const userIds = (await getAllUsers({ page: 1, limit: 1000000 })).users.map(user => user._id.toString());
   session.startTransaction();
 
@@ -874,6 +874,48 @@ const getEventsBatchRepo = async ({
   return { events };
 };
 
+const getActiveEventsCountForOrganizations = async (
+  organizationIds = []
+) => {
+  if (!Array.isArray(organizationIds) || organizationIds.length === 0) {
+    return [];
+  }
+
+  const objectIds = organizationIds.map(
+    (id) => new mongoose.Types.ObjectId(id)
+  );
+
+  return Events.aggregate([
+    {
+      $match: {
+        "basicInfo.organization": { $in: objectIds },
+        status: "active",
+        "recurringMeta.isTemplate": { $ne: true },
+
+        $or: [
+          {
+            "schedule.endDateTime": {
+              $gte: new Date(),
+            },
+          },
+          {
+            "schedule.endDateTime": null,
+            "schedule.startDateTime": {
+              $gte: new Date(),
+            },
+          },
+        ],
+      },
+    },
+    {
+      $group: {
+        _id: "$basicInfo.organization",
+        count: { $sum: 1 },
+      },
+    },
+  ]);
+};
+
 module.exports = {
   createEvent,
   getEventsWithFilters,
@@ -900,5 +942,6 @@ module.exports = {
   getEventsByVenueType,
   getEventsByTag,
   getEventsByCategory,
-  getEventsBatchRepo
+  getEventsBatchRepo,
+  getActiveEventsCountForOrganizations
 };

--- a/backend/admin/events/updateEventService.js
+++ b/backend/admin/events/updateEventService.js
@@ -7,6 +7,7 @@
  */
 
 const { Events } = require("@EventsModel");
+const { uniqueObjectIds } = require("../../helperUtils/responseUtil");
 
 const updateEventService = async (eventId, payload, mode = "single") => {
 
@@ -23,9 +24,24 @@ const updateEventService = async (eventId, payload, mode = "single") => {
   // SAFE FIELD APPLIER
   // -----------------------------
   const applyFields = (doc, data, skipSchedule = false) => {
-    if (data.basicInfo) {
-      doc.basicInfo = { ...doc.basicInfo, ...data.basicInfo };
+
+    doc.basicInfo = {
+      ...doc.basicInfo,
+      ...data.basicInfo,
+    };
+
+    if (data.basicInfo?.categories) {
+      doc.basicInfo.categories = uniqueObjectIds(
+        data.basicInfo.categories
+      );
     }
+
+    if (data.basicInfo?.tags) {
+      doc.basicInfo.tags = uniqueObjectIds(
+        data.basicInfo.tags
+      );
+    }
+
 
     if (!skipSchedule && data.schedule) {
       doc.schedule = { ...doc.schedule, ...data.schedule };
@@ -36,7 +52,7 @@ const updateEventService = async (eventId, payload, mode = "single") => {
 
     if (data.status !== undefined)
       doc.status = data.status;
-    if(data.feedbackEnabled !== undefined)
+    if (data.feedbackEnabled !== undefined)
       doc.feedbackEnabled = data.feedbackEnabled;
 
     // recurringDetails may change too
@@ -52,12 +68,12 @@ const updateEventService = async (eventId, payload, mode = "single") => {
   // NON-RECURRING OR SINGLE MODE
   // ================================================
   if (mode === "single" || !isChild) {
- 
+
 
     applyFields(event, payload);
     await event.save();
 
- 
+
     return event;
   }
 
@@ -65,7 +81,7 @@ const updateEventService = async (eventId, payload, mode = "single") => {
   // FUTURE MODE
   // ================================================
 
- 
+
 
   const parentId = event.recurringMeta.parentEvent;
   const template = await Events.findById(parentId);
@@ -80,7 +96,7 @@ const updateEventService = async (eventId, payload, mode = "single") => {
   // -------------------------------------------
   // STEP 1 — UPDATE THE CURRENT OCCURRENCE
   // -------------------------------------------
- 
+
 
   applyFields(event, payload);
 

--- a/backend/admin/feedConfig/FeedConfig.js
+++ b/backend/admin/feedConfig/FeedConfig.js
@@ -1,0 +1,18 @@
+const mongoose = require("mongoose");
+
+const feedConfigSchema = new mongoose.Schema(
+  {
+    quickAction: { //hides/shows categories on the app home feed
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+
+const FeedConfig = mongoose.model("FeedConfig", feedConfigSchema);
+
+module.exports = FeedConfig;

--- a/backend/admin/feedConfig/feedConfigController.js
+++ b/backend/admin/feedConfig/feedConfigController.js
@@ -1,0 +1,69 @@
+const {
+  sendResponse,
+  validateParams,
+  getReadableErrorMessage,
+} = require("../../helperUtils/responseUtil");
+
+const feedConfigService = require("./feedConfigService");
+
+const getFeedConfig = async (req, res) => {
+  try {
+    const feedConfig = await feedConfigService.getFeedConfig();
+
+    return sendResponse({
+      res,
+      statusCode: 200,
+      translationKey: "data_fetched_successfully",
+      data: feedConfig,
+    });
+  } catch (error) {
+    const readableError = getReadableErrorMessage(error);
+    return sendResponse({
+      res,
+      statusCode: readableError.statusCode,
+      translationKey: readableError.message,
+      error,
+    });
+  }
+};
+
+const updateFeedConfig = async (req, res) => {
+  if (!validateParams(req, res, { rawData: ["quickAction"] })) return;
+
+  const { quickAction } = req.body;
+
+  if (typeof quickAction !== "boolean") {
+    return sendResponse({
+      res,
+      statusCode: 400,
+      translationKey: "invalid_parameters",
+      values: { fields: "quickAction" },
+    });
+  }
+
+  try {
+    const updatedFeedConfig = await feedConfigService.updateFeedConfig({
+      quickAction,
+    });
+
+    return sendResponse({
+      res,
+      statusCode: 200,
+      translationKey: "admin_settings_3",
+      data: updatedFeedConfig,
+    });
+  } catch (error) {
+    const readableError = getReadableErrorMessage(error);
+    return sendResponse({
+      res,
+      statusCode: readableError.statusCode,
+      translationKey: readableError.message,
+      error,
+    });
+  }
+};
+
+module.exports = {
+  getFeedConfig,
+  updateFeedConfig,
+};

--- a/backend/admin/feedConfig/feedConfigRepository.js
+++ b/backend/admin/feedConfig/feedConfigRepository.js
@@ -1,0 +1,47 @@
+const FeedConfig = require("./FeedConfig");
+const { cache, invalidate } = require("@redisCache");
+
+const CACHE_KEY = "feed-config";
+
+const findFeedConfig = async () => {
+  return FeedConfig.findOne().sort({ createdAt: 1 });
+};
+
+const findOrCreateFeedConfig = async () => {
+  return cache({
+    namespace: CACHE_KEY,
+    ttl: null,
+    fetchFn: async () => {
+      let config = await findFeedConfig();
+
+      if (!config) {
+        config = await FeedConfig.create({});
+      }
+
+      return config;
+    },
+  });
+};
+
+const updateFeedConfig = async (data) => {
+  const updated = await FeedConfig.findOneAndUpdate(
+    {},
+    { $set: data },
+    {
+      new: true,
+      upsert: true,
+      setDefaultsOnInsert: true,
+      sort: { createdAt: 1 },
+    }
+  );
+
+  await invalidate(CACHE_KEY);
+
+  return updated;
+};
+
+module.exports = {
+  findFeedConfig,
+  findOrCreateFeedConfig,
+  updateFeedConfig,
+};

--- a/backend/admin/feedConfig/feedConfigRoutes.js
+++ b/backend/admin/feedConfig/feedConfigRoutes.js
@@ -1,0 +1,18 @@
+const express = require("express");
+const createRateLimiter = require("../../helperUtils/rateLimiter");
+const auth = require("../../middlewares/authMiddleware");
+const roleMiddleware = require("../../middlewares/roleMiddleware");
+const {
+  getFeedConfig,
+  updateFeedConfig,
+} = require("./feedConfigController");
+
+const router = express.Router();
+const apiRateLimiter = createRateLimiter("FeedConfig");
+
+router.use(auth);
+
+router.get("/quick-action", apiRateLimiter, getFeedConfig);
+router.patch("/quick-action", roleMiddleware(["admin"]), updateFeedConfig);
+
+module.exports = router;

--- a/backend/admin/feedConfig/feedConfigService.js
+++ b/backend/admin/feedConfig/feedConfigService.js
@@ -1,0 +1,14 @@
+const feedConfigRepository = require("./feedConfigRepository");
+
+const getFeedConfig = async () => {
+  return feedConfigRepository.findOrCreateFeedConfig();
+};
+
+const updateFeedConfig = async ({ quickAction }) => {
+  return feedConfigRepository.updateFeedConfig({ quickAction });
+};
+
+module.exports = {
+  getFeedConfig,
+  updateFeedConfig,
+};

--- a/backend/admin/inAppOrdering/menuManagement/menuManagementController.js
+++ b/backend/admin/inAppOrdering/menuManagement/menuManagementController.js
@@ -620,6 +620,7 @@ const getSaleItems = async (req, res) => {
 
 const updateSaleItems = async (req, res) => {
   const { id } = req.params;
+  const timezone = req.user?.timezone;
   const {
     status,
     title,
@@ -633,6 +634,10 @@ const updateSaleItems = async (req, res) => {
     !validateParams(req, res, {
       pathParams: ["id"],
       objectIdFields: ["id"],
+      dateFields: {
+        startDateTime: "YYYY-MM-DD hh:mm A",
+        endDateTime: "YYYY-MM-DD hh:mm A",
+      },
     })
   ) return;
 
@@ -647,10 +652,18 @@ const updateSaleItems = async (req, res) => {
     endDateTime,
   };
 
+  if (startDateTime !== undefined) {
+    data.startDateTime = convertTimezoneToUtc(startDateTime, timezone, "YYYY-MM-DD hh:mm A");
+  }
+
+  if (endDateTime !== undefined) {
+    data.endDateTime = convertTimezoneToUtc(endDateTime, timezone, "YYYY-MM-DD hh:mm A");
+  }
+
 
 
   try {
-    const updated = await Menuervice.updateSaleItems(id, data);
+    const updated = await Menuervice.updateSaleItems(id, data, timezone);
     if (updated && updated.error) {
       return sendResponse({
         res,

--- a/backend/admin/inAppOrdering/menuManagement/menuManagementRepository.js
+++ b/backend/admin/inAppOrdering/menuManagement/menuManagementRepository.js
@@ -1,5 +1,5 @@
 
-const { generateMeta } = require("@utils/responseUtil");
+const { generateMeta, convertUtcToTimezone } = require("@utils/responseUtil");
 const mongoose = require("mongoose");
 const Organizations = require("@OrganizationModel");
 const { UserReservations } = require("@UserReservationsModel");
@@ -271,6 +271,7 @@ const fetchMenuItems = async (organization) => {
   }
 };
 const getMenuItemsSales = async ({
+  timezone,
   page = 1,
   limit = 3,
   skip = 0,
@@ -473,6 +474,14 @@ const getMenuItemsSales = async ({
 
     // ✅ FORMAT IMAGES HERE
     sale = formatSaleWithImages(sale);
+
+    if (sale.startDateTime) {
+      sale.startDateTime = convertUtcToTimezone(sale.startDateTime, timezone, "YYYY-MM-DD hh:mm A");
+    }
+
+    if (sale.endDateTime) {
+      sale.endDateTime = convertUtcToTimezone(sale.endDateTime, timezone, "YYYY-MM-DD hh:mm A");
+    }
 
     return {
       ...sale,

--- a/backend/admin/inAppOrdering/menuManagement/menuManagementService.js
+++ b/backend/admin/inAppOrdering/menuManagement/menuManagementService.js
@@ -1,4 +1,4 @@
-const { getCurrentDateInTimezone } = require("@utils/responseUtil");
+const { getCurrentDateInTimezone, convertUtcToTimezone } = require("@utils/responseUtil");
 const MenuRepo = require("./menuManagementRepository");
 const { NotificationTypes } = require("@NotificationsModel");
 const MenuItems = require("@MenuItemsModel");
@@ -404,7 +404,7 @@ const getSaleItems = async ({ timezone,
     meta,
   };
 };
-const updateSaleItems = async (id, data) => {
+const updateSaleItems = async (id, data, timezone) => {
   const order = await MenuRepo.findSaleById(id);
   if (!order) {
     return { error: "Menu_not_found" };
@@ -442,17 +442,27 @@ if (data.menuItems && Array.isArray(data.menuItems)) {
 }
 
 
-  // Update date range
+  // Date values are already converted to UTC in controller.
   if (data.startDateTime !== undefined) {
-    order.startDateTime = new Date(data.startDateTime);
+    order.startDateTime = data.startDateTime;
   }
 
   if (data.endDateTime !== undefined) {
-    order.endDateTime = new Date(data.endDateTime);
+    order.endDateTime = data.endDateTime;
   }
 
   await order.save();
-  return order;
+  const updated = order.toObject();
+
+  if (updated.startDateTime) {
+    updated.startDateTime = convertUtcToTimezone(updated.startDateTime, timezone, "YYYY-MM-DD hh:mm A");
+  }
+
+  if (updated.endDateTime) {
+    updated.endDateTime = convertUtcToTimezone(updated.endDateTime, timezone, "YYYY-MM-DD hh:mm A");
+  }
+
+  return updated;
 };
 
 const deleteSaleItems = async (id) => {

--- a/backend/admin/menuManagement/menuItemCategories/formatter/formatItemCategories.js
+++ b/backend/admin/menuManagement/menuItemCategories/formatter/formatItemCategories.js
@@ -14,8 +14,21 @@ function formatMenuItem(item, timezone) {
   if (!obj) return null;
 
   obj.image = getFullImageUrl(obj.image || "noimage.png");
-  obj.startTime=convertUtcToTimezone(obj.startTime,timezone,"hh:mm A");
-  obj.endTime=convertUtcToTimezone(obj.endTime,timezone,"hh:mm A");
+  if (obj.startTime) {
+    obj.startTime = convertUtcToTimezone(obj.startTime, timezone, "hh:mm A");
+  }
+
+  if (obj.endTime) {
+    obj.endTime = convertUtcToTimezone(obj.endTime, timezone, "hh:mm A");
+  }
+
+  if (obj.startDate) {
+    obj.startDate = convertUtcToTimezone(obj.startDate, timezone, "YYYY-MM-DD");
+  }
+
+  if (obj.endDate) {
+    obj.endDate = convertUtcToTimezone(obj.endDate, timezone, "YYYY-MM-DD");
+  }
 
   // ✅ SAFE MENU HANDLING
   if (obj.menuData) {

--- a/backend/admin/menuManagement/menuItems/menuItemsController.js
+++ b/backend/admin/menuManagement/menuItems/menuItemsController.js
@@ -2,9 +2,7 @@ const {
   sendResponse,
   parsePaginationParams,
   validateParams,
-  generateMeta,
   getReadableErrorMessage,
-  convertDateFormat,
   convertTimezoneToUtc,
 } = require("@utils/responseUtil");
 
@@ -54,12 +52,12 @@ const createMenuItem = async (req, res) => {
     creator: req.user?._id,
   };
 
-  if (startTime && endTime) {
+  if (startTime) {
     data.startTime = convertTimezoneToUtc(startTime, timezone, "hh:mm A");
+  }
+
+  if (endTime) {
     data.endTime = convertTimezoneToUtc(endTime, timezone, "hh:mm A");
-
-
-
   }
 
   try {
@@ -165,7 +163,7 @@ const getMenuItemDetails = async (req, res) => {
     return;
 
   try {
-    const menuItem = await menuItemsService.getMenuItemDetails(id);
+    const menuItem = await menuItemsService.getMenuItemDetails(id, req.user?.timezone);
     if (!menuItem) {
       return sendResponse({
         res,
@@ -286,8 +284,11 @@ const updateMenuItem = async (req, res) => {
   };
 
   try {
-    if (startDate && endDate) {
+    if (startDate) {
       data.startDate = convertTimezoneToUtc(startDate, timezone, "YYYY-MM-DD");
+    }
+
+    if (endDate) {
       data.endDate = convertTimezoneToUtc(endDate, timezone, "YYYY-MM-DD");
     }
     const allowedAvailabilityTypes = ['preOrdersOnly', 'preOrdersEvent', 'preOrderExclusive'];
@@ -300,17 +301,12 @@ const updateMenuItem = async (req, res) => {
       });
     }
 
-    if (startTime && endTime) {
+    if (startTime) {
       data.startTime = convertTimezoneToUtc(startTime, req.user.timezone, "hh:mm A");
-      data.endTime = convertTimezoneToUtc(endTime, req.user.timezone, "hh:mm A");
-
-
     }
-    if (startDate && endDate) {
-      data.startDate = convertTimezoneToUtc(startDate, req.user.timezone, "hh:mm A");
-      data.endDate = convertTimezoneToUtc(endDate, req.user.timezone, "hh:mm A");
 
-
+    if (endTime) {
+      data.endTime = convertTimezoneToUtc(endTime, req.user.timezone, "hh:mm A");
     }
      id = new mongoose.Types.ObjectId(id);
 
@@ -390,7 +386,7 @@ const getMenuItemsByMenuId = async (req, res) => {
     return;
 
   try {
-    const menuItems = await menuItemsService.getMenuItemsByMenuId(menuId);
+    const menuItems = await menuItemsService.getMenuItemsByMenuId(menuId, req.user?.timezone);
     return sendResponse({
       res,
       statusCode: 200,

--- a/backend/admin/menuManagement/menuItems/menuItemsService.js
+++ b/backend/admin/menuManagement/menuItems/menuItemsService.js
@@ -200,10 +200,10 @@ const deleteMenuItem = async (id) => {
   return true;
 };
 
-const getMenuItemDetails = async (id) => {
+const getMenuItemDetails = async (id, timezone) => {
   const menuItem = await menuItemRepo.findMenuItemById(id);
   if (!menuItem) return null;
-  return menuItem;
+  return formatMenuItem(menuItem, timezone);
 };
 
 

--- a/backend/admin/organizations/organizationService.js
+++ b/backend/admin/organizations/organizationService.js
@@ -8,6 +8,7 @@ const { generateMeta } = require("../../helperUtils/responseUtil");
 const { formatOrganization, formatNotificationImage } = require("./formatter/formatOrganization");
 const { default: mongoose } = require("mongoose");
 const { invalidate } = require("@redisCache");
+const { getActiveEventsCountForOrganizations } = require("../events/eventRepository");
 const ACTIVE_ORGANIZATIONS_CACHE_KEY = "organizations:active";
 const createOrganization = async ({ data, timezone }) => {
   let org = await organizationRepo.createOrganization(data);
@@ -112,6 +113,25 @@ const getOrganizationsByAdmin = async ({ companyOrganizer, page, limit, keyword,
   let meta = generateMeta(page, limit, totalFiltered);
   meta.tagsCount = { total, active, inactive };
   organizations = organizations.map(org => formatOrganization(org, [], timezone));
+  //get active events count of each organization and add to organization object
+  const organizationIds = organizations.map(org => org._id);
+  const eventsCounts = await getActiveEventsCountForOrganizations(organizationIds);
+  const eventsCountMap = new Map(
+    eventsCounts.map(e => [
+      e._id.toString(),
+      e.count
+    ])
+  );
+
+  organizations = organizations.map(org => ({
+    ...org,
+
+    meta: {
+      ...(org.meta || {}),
+      activeEventsCount:
+        eventsCountMap.get(org._id.toString()) || 0,
+    },
+  }));
 
   return {
     organizations,

--- a/backend/admin/routes/index.js
+++ b/backend/admin/routes/index.js
@@ -72,6 +72,7 @@ router.use("/faqs", require("../faqs/faqsRoutes"));
 router.use("/badge-categories", require("../badgeCategories/badgeCategoriesRoutes"));
 router.use("/reviews", require("../reviews/reviewsRoutes"));
 router.use("/support", require("../support/supportRoutes"));
+router.use("/feed-config", require("../feedConfig/feedConfigRoutes"));
 
 
 

--- a/backend/admin/transactions/repositories/unifiedTransactionsRepository.js
+++ b/backend/admin/transactions/repositories/unifiedTransactionsRepository.js
@@ -344,16 +344,13 @@ const attachBookings = async (txList) => {
 // Helper function to fetch bookings for each domain
 const getBookingsForDomain = async (domain, orderIds) => {
   try {
-    console.log(`Fetching bookings for domain: ${domain} with orderIds:`, orderIds);
     
     let bookings = [];
     switch (domain) {
       case "ticketingorders":
-        console.log("enter ticketingorders", );
         bookings = await TicketingOrders.find({ _id: { $in: orderIds } }).lean();
         break;
       case "menuorders":
-        console.log("enter manuoser", );
         bookings = await Orders.find({ _id: { $in: orderIds } }).lean();
         break;
       case "ticketingbookings":
@@ -377,7 +374,6 @@ const getBookingsForDomain = async (domain, orderIds) => {
 
     return bookings;
   } catch (error) {
-    console.error(`Error fetching bookings for ${domain}:`, error);
     return [];
   }
 };

--- a/backend/admin/venueTypes/venueTypesController.js
+++ b/backend/admin/venueTypes/venueTypesController.js
@@ -46,7 +46,7 @@ const createVenueType = async (req, res) => {
 
 const getVenueTypes = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
-  const { keyword, status, date } = req.query;
+  const { keyword, status, date, categories } = req.query;
 
   try {
 
@@ -62,7 +62,8 @@ const getVenueTypes = async (req, res) => {
       limit,
       keyword,
       status,
-      date
+      date,
+      categories
     });
 
     return sendResponse({
@@ -84,7 +85,7 @@ const getVenueTypes = async (req, res) => {
 
 const getPublicVenueTypes = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
-  const { keyword, date } = req.query;
+  const { keyword, date, categories } = req.query;
   try {
 
     if (date && !validateParams(req, res, {
@@ -98,7 +99,8 @@ const getPublicVenueTypes = async (req, res) => {
       page,
       limit,
       keyword,
-      date
+      date,
+      categories
     });
 
     return sendResponse({

--- a/backend/admin/venueTypes/venueTypesService.js
+++ b/backend/admin/venueTypes/venueTypesService.js
@@ -7,7 +7,7 @@ const venuetypeRepo = require("./venueTypesRepository");
 const createVenueType = async ({ image, title, status, categories }) => {
   return await venuetypeRepo.createVenueType({ image, title, status, categories });
 };
-const getVenueTypes = async ({ page, limit, keyword, status, date }) => {
+const getVenueTypes = async ({ page, limit, keyword, status, date, categories }) => {
   const andConditions = [];
   // if date is available then match createdAt with date current date format is yyyy-mm-dd
   if (date) {
@@ -25,6 +25,11 @@ const getVenueTypes = async ({ page, limit, keyword, status, date }) => {
     andConditions.push({ status: { $ne: "deleted" } });
   }
 
+  // if category filter is available then match categories with category filter
+  //sample category filter value is categories=catId1,catId2
+  if (categories) {
+    andConditions.push({ categories: { $in: categories.split(",").map(id => new mongoose.Types.ObjectId(id)) } });
+  }
 
   let query = andConditions.length > 0 ? { $and: andConditions } : {};
   //attach keyword filter if available
@@ -62,7 +67,7 @@ const getVenueTypes = async ({ page, limit, keyword, status, date }) => {
   };
 };
 
-const getPublicVenueTypes = async ({ page = 1, limit, keyword, date, categoriesFilter = [] }) => {
+const getPublicVenueTypes = async ({ page = 1, limit, keyword, date, categories = [] }) => {
   const baseFilters = [{ status: "active" }];
   //if date is available then match createdAt with date current date format is yyyy-mm-dd
   if (date) {
@@ -85,9 +90,9 @@ const getPublicVenueTypes = async ({ page = 1, limit, keyword, date, categoriesF
 
   const baseQuery = baseFilters.length ? { $and: baseFilters } : {};
 
-  if (categoriesFilter.length > 0) {
-    categoriesFilter = categoriesFilter.map(id => new mongoose.Types.ObjectId(id));
-    baseQuery.categories = { $in: categoriesFilter };
+  if (categories.length > 0) {
+    categories = categories.map(id => new mongoose.Types.ObjectId(id));
+    baseQuery.categories = { $in: categories };
   }
 
   const [venueTypes, totalFiltered] =

--- a/backend/app/globalLoyalty/rewardsOrders/rewardsOrdersRepository.js
+++ b/backend/app/globalLoyalty/rewardsOrders/rewardsOrdersRepository.js
@@ -75,7 +75,7 @@ const createGlobalRewardOrder = async ({
         {
           user: userId,
           type: "redeem",
-          domainType: "ticketingorders",
+          domainType: "globalrewardsorders",
           entityId: result.order._id,
           globalPoints: {
             base: reward.minPointsRequiredToClaim || 0,

--- a/backend/app/home/homeService.js
+++ b/backend/app/home/homeService.js
@@ -25,7 +25,8 @@ const { getGlobalReferralSettingsRepository } = require("../../admin/globalLoyal
 const { getAppSettings } = require("../appSettings/appSettingsController");
 const { getPinnedContentWithFilters } = require("../../admin/pinnedContent/pinnedContentRepository");
 const { getEventsByVenueTypeService, getEventsByTagService, getEventsByCategoryService, getEventsBatch } = require("../../admin/events/eventService");
-const { getOrganizationsByVenueTypeService, getOrganizationsByTagService, getOrganizationByCategoryService, getOrganizationsBatch  } = require("../../admin/organizations/organizationService");
+const { getOrganizationsByVenueTypeService, getOrganizationsByTagService, getOrganizationByCategoryService, getOrganizationsBatch } = require("../../admin/organizations/organizationService");
+const { findOrCreateFeedConfig } = require("../../admin/feedConfig/feedConfigRepository");
 
 const getHomeService = async ({ queryData }) => {
   const { userId, userLocation, radiusKm = 50, timezone, category } = queryData;
@@ -42,10 +43,19 @@ const getHomeService = async ({ queryData }) => {
     /**
      * PROMISES
      */
-    let filter = { quickAction: true }
+
+    //fist check if getFeedConfig has quickAction enabled, if not then return empty array
+
+    const feedConfig = await findOrCreateFeedConfig();
+
+
 
     const promises = {
-      categoriesRes: getPublicCategories(filter),
+      ...(feedConfig?.quickAction && {
+        categoriesRes: getPublicCategories({
+          status: "active",
+        }),
+      }),
       bannersRes: getBannerControlsService({ page: 1, limit: 10 }),
       getGlobalReferralSettingsRes: getGlobalReferralSettingsRepository(),
 
@@ -191,7 +201,7 @@ const getHomeService = async ({ queryData }) => {
     /**
      * NORMALIZATION
      */
-    const categories = results.categoriesRes?.categories || [];
+    let categories = results.categoriesRes?.categories || [];
     const banners = results.bannersRes?.bannerControls || [];
     const getGlobalReferralSettings = results.getGlobalReferralSettingsRes || null;
     const popularEvents = results.popularEventsRes?.data || [];

--- a/backend/app/loyalty/rewardsOrders/rewardsOrdersRepository.js
+++ b/backend/app/loyalty/rewardsOrders/rewardsOrdersRepository.js
@@ -92,9 +92,10 @@ const createRewardOrder = async ({ userId, rewardId, protectionUserDetails, time
         {
           user: userId,
           companyOrganizer: reward.companyOrganizer,
+          organization: orderDoc?.order?.organization || null,
           type: "redeem",
-          domainType: "ticketingorders",
-          entityId: orderDoc._id,
+          domainType: "loyaltyrewardsorders",
+          entityId: orderDoc?.order?._id,
           companyPoints: {
             base: reward.minPointsRequiredToClaim || 0,
             total: -(reward.minPointsRequiredToClaim || 0),

--- a/backend/app/publicCategories/categoriesService.js
+++ b/backend/app/publicCategories/categoriesService.js
@@ -4,6 +4,9 @@ const { formatCategories } = require("../../admin/categories/formatters/category
 const getPublicCategories = async (filter = {}) => {
   //only return selected fields
   let categories = await getPublicActiveCategories(filter);
+  if (!categories || categories.length === 0) {
+    return [];
+  }
   categories = formatCategories(categories);
 
   return { categories };

--- a/backend/commonModules/events/Event.js
+++ b/backend/commonModules/events/Event.js
@@ -48,20 +48,21 @@ const eventSchema = new mongoose.Schema(
         type: LocationSchema,
         default: {},
       },
-      categories: [
-        {
+      categories: {
+        type: [{
           type: mongoose.Schema.Types.ObjectId,
           ref: "Categories",
-          default: [],
-        },
-      ],
-      tags: [
-        {
+        }],
+        default: [],
+      },
+
+      tags: {
+        type: [{
           type: mongoose.Schema.Types.ObjectId,
           ref: "Tags",
-          default: [],
-        },
-      ],
+        }],
+        default: [],
+      },
       partnerOrganization: {
         type: mongoose.Schema.Types.ObjectId,
         ref: "Organizations",

--- a/backend/helperUtils/responseUtil.js
+++ b/backend/helperUtils/responseUtil.js
@@ -851,6 +851,10 @@ const fireAndForget = (promise, label) => {
   );
 };
 
+const uniqueObjectIds = (arr = []) => {
+  return [...new Set(arr.map(id => id.toString()))];
+};
+
 module.exports = {
   sendResponse,
   parsePaginationParams,
@@ -874,4 +878,5 @@ module.exports = {
   extractTime,
   getEndDate,
   fireAndForget,
+  uniqueObjectIds,
 };


### PR DESCRIPTION
Remove quickAction from Category schema and related create/update flows; introduce FeedConfig model, repository, service, controller and routes to centrally control feed quick-action visibility. Add uniqueObjectIds utility and use it to deduplicate category/tag IDs in event creation and updates; update Event schema to enforce array types with defaults for categories and tags. Add getActiveEventsCountForOrganizations aggregation in events repository and surface activeEventsCount in organization responses. Add categories filtering support to venue types (admin & public), adjust home service to respect feedConfig.quickAction, handle empty public categories, fix domainType/entityId handling in rewards orders, and remove debug logs from unified transactions repository. Register new /feed-config admin routes.