### PR TITLE
Add favorite counts and sorting to events

### DIFF
--- a/backend/admin/events/eventController.js
+++ b/backend/admin/events/eventController.js
@@ -312,7 +312,7 @@ const createEvent = async (req, res) => {
 const getEvents = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
   let { keyword, status, startDate, endDate, organization,venue, companyOrganizer, sortBy, sortOrder,date } = req.query;
-  const SORT_FIELDS = ["eventName", "venueName", "organizationName","startDate","endDate","revenue","views","status"];
+  const SORT_FIELDS = ["eventName", "venueName", "organizationName","startDate","endDate","revenue","views","status","favorite"];
   const SORT_ORDERS = ["asc", "desc"];
   if ((sortBy && !SORT_FIELDS.includes(sortBy)) || (sortOrder && !SORT_ORDERS.includes(sortOrder))) {
     const key = sortBy && !SORT_FIELDS.includes(sortBy)

--- a/backend/admin/events/eventRepository.js
+++ b/backend/admin/events/eventRepository.js
@@ -119,7 +119,6 @@ const getEventsWithFilters = async (
   sortBy,
   sortOrder,
   venue,
-  
 ) => {
   // Helper to safely convert query to $and format for aggregation
 
@@ -228,12 +227,32 @@ const getEventsWithFilters = async (
         as: "_viewStats",
       },
     },
+    {
+      $lookup: {
+        from: "engagementevents", // confirm actual collection name
+        let: { eventId: "$_id" },
+        pipeline: [
+          {
+            $match: {
+              $expr: { $eq: ["$entityId", "$$eventId"] },
+              entityType: "events",
+              action: "favorite",
+            },
+          },
+          { $count: "totalFavorites" },
+        ],
+        as: "_favoriteStats",
+      },
+    },
     // Flatten into numeric fields for sorting
     {
       $addFields: {
         _revenue: { $ifNull: [{ $first: "$_ticketStats.totalRevenue" }, 0] },
         _tickets: { $ifNull: [{ $first: "$_ticketStats.totalTickets" }, 0] },
         _views: { $ifNull: [{ $first: "$_viewStats.totalViews" }, 0] },
+        _favorites: {
+          $ifNull: [{ $first: "$_favoriteStats.totalFavorites" }, 0],
+        },
       },
     },
   ];
@@ -286,6 +305,8 @@ const getEventsWithFilters = async (
     pipeline.push({ $sort: { "schedule.startDateTime": sortDirection } });
   } else if (sortBy === "endDate") {
     pipeline.push({ $sort: { "schedule.endDateTime": sortDirection } });
+  } else if (sortBy === "favorite") {
+    pipeline.push({ $sort: { _favorites: sortDirection } });
   } else if (sortBy === "status") {
     pipeline.push({
       $addFields: {

--- a/backend/admin/events/eventService.js
+++ b/backend/admin/events/eventService.js
@@ -292,6 +292,7 @@ const getEvents = async ({
       totalTickets: event._tickets || 0,
       totalRevenue: event._revenue || 0,
       totalViews: event._views || 0,
+      totalFavorites: event._favorites || 0,
     },
   }));
 


### PR DESCRIPTION
Expose event favorite counts and enable sorting by favorites. Added "favorite" to controller's SORT_FIELDS, added an aggregation $lookup to count "favorite" actions from the engagementevents collection and flattened it into _favorites, and added sorting logic for sortBy === "favorite". The service now includes totalFavorites in the returned event summary. Also removed an extra trailing comma in the repository function signature.