### PR TITLE
Add admin 'getAll' endpoint and subtype filter

### DIFF
--- a/backend/admin/organizations/organizationController.js
+++ b/backend/admin/organizations/organizationController.js
@@ -9,7 +9,26 @@ const {
 const { transformOperatingHoursToUtc } = require("../../shared/commonSchemas/operatingHours");
 
 const organizationService = require("./organizationService");
+const getAllOrganizationsAdmin = async (req, res) => {
+  const { timezone } = req.user;
+  try {
+    const organizations = await organizationService.getAllOrganizationsAdmin({ timezone });
 
+    return sendResponse({
+      res,
+      statusCode: 200,
+      translationKey: "organizations_fetched_successfully",
+      data: organizations,
+    });
+  } catch (error) {
+    return sendResponse({
+      res,
+      statusCode: 500,
+      translationKey: "internal_server",
+      error,
+    });
+  }
+};
 const createOrganization = async (req, res) => {
 
   let { timezone } = req.user
@@ -110,7 +129,7 @@ const getOrganizations = async (req, res) => {
 
 const getOrganizationsAdmin = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
-  const { keyword, date, status = "active", companyOrganizer, sortBy, sortOrder } = req.query;
+  const { keyword, date, status = "active", companyOrganizer, sortBy, sortOrder,organization,subType } = req.query;
   let { timezone } = req.user;
   try {
     if (date && !validateParams(req, res, {
@@ -143,7 +162,9 @@ const getOrganizationsAdmin = async (req, res) => {
       date,
       timezone,
       sortBy,
-      sortOrder
+      sortOrder,
+      organization,
+      subType
     });
     return sendResponse({
       res,
@@ -450,5 +471,6 @@ module.exports = {
   getOrganizationNamesByCompanyOrganizer,
   getOrganizationNotifications,
   getOrganizationsByTag,
-  getOrganizationsByVenueType
+  getOrganizationsByVenueType,
+  getAllOrganizationsAdmin
 };

--- a/backend/admin/organizations/organizationRepository.js
+++ b/backend/admin/organizations/organizationRepository.js
@@ -3,6 +3,9 @@ const Venues = require("@VenuesModel");
 
 const Organizations = require("@OrganizationModel");
 const Menus = require("@MenusModel");
+
+
+
 const { getModelCounts } = require("@dbUtils/queryUtil");
 const {
   getPromotionsByCreator,
@@ -28,6 +31,11 @@ const { getActiveSubscription } = require("../usersManagement/usersRepository");
 const { getFullImageUrl } = require("@utils/imageHelper");
 
 // Create
+
+
+const getAllOrganizationsAdmin = async () => {
+  return await Organizations.find({status: { $eq: "active" }}).select("_id basicInfo.name").lean();
+};
 const createOrganization = async (data) => {
   const NoOrganizationCount = await Organizations.countDocuments({
     creator: new mongoose.Types.ObjectId(data.creator),
@@ -50,6 +58,7 @@ const getOrganizationsWithFilters = async (
   limit,
   sortBy,
   sortOrder,
+  subType
 ) => {
   const matchQuery = { ...query };
 
@@ -209,6 +218,13 @@ const getOrganizationsWithFilters = async (
       },
     },
   ];
+if (subType) {
+  pipeline.push({
+    $match: {
+      "user.activeSubscription.subscriptionTypes": subType, 
+    },
+  });
+}
   if (sortBy && sortOrder) {
     if (sortBy === "organizationName") {
       pipeline.push({
@@ -1126,4 +1142,5 @@ module.exports = {
   getOrganizationByCategory,
   getOrganizationsBatchRepo,
   getCreatorByStaffId,
+  getAllOrganizationsAdmin,
 };

--- a/backend/admin/organizations/organizationRoutes.js
+++ b/backend/admin/organizations/organizationRoutes.js
@@ -8,7 +8,8 @@ const {
   getOrganizationNotifications,
   getOrganizationNamesByCompanyOrganizer,
   getOrganizationsByTag,
-  getOrganizationsByVenueType
+  getOrganizationsByVenueType,
+  getAllOrganizationsAdmin,
 } = require("./organizationController");
 const createRateLimiter = require("../../helperUtils/rateLimiter");
 const auth = require("../../middlewares/authMiddleware");
@@ -20,7 +21,7 @@ router.use(auth);
 
 // Create a rate limiter for Organizations
 const apiRateLimiter = createRateLimiter("Organizations");
-
+router.get("/all", apiRateLimiter, getAllOrganizationsAdmin);
 // Create a new organization
 router.post("/", roleMiddleware(["organizer", "admin", "manager"]), createOrganization);
 
@@ -36,6 +37,7 @@ router.put("/:id", roleMiddleware(["organizer", "admin", "manager", "staff"]), u
 
 // Delete a organization
 router.delete("/:id", deleteOrganization);
+ // Get all organizations without pagination
 
 //getOrganizationNamesByCompanyOrganizer
 router.get("/names/by-company-organizer/:companyOrganizer", apiRateLimiter, getOrganizationNamesByCompanyOrganizer);

--- a/backend/admin/organizations/organizationService.js
+++ b/backend/admin/organizations/organizationService.js
@@ -14,7 +14,10 @@ const createOrganization = async ({ data, timezone }) => {
   let org = await organizationRepo.createOrganization(data);
   return formatOrganization(org, [], timezone);
 };
+const getAllOrganizationsAdmin = async ({ timezone }) => {
+  return await organizationRepo.getAllOrganizationsAdmin();
 
+}
 const getOrganizations = async ({ page, limit, keyword, status, creator, date, timezone }) => {
   const query = {};
   query.$or = [
@@ -67,7 +70,7 @@ const getOrganizations = async ({ page, limit, keyword, status, creator, date, t
   };
 };
 
-const getOrganizationsByAdmin = async ({ companyOrganizer, page, limit, keyword, status, date, timezone, sortBy, sortOrder }) => {
+const getOrganizationsByAdmin = async ({ companyOrganizer, page, limit, keyword, status, date, timezone, sortBy, sortOrder, organization, subType }) => {
   const query = {};
   if (companyOrganizer) {
     query.creator = new mongoose.Types.ObjectId(companyOrganizer);
@@ -77,6 +80,9 @@ const getOrganizationsByAdmin = async ({ companyOrganizer, page, limit, keyword,
     query.status = status;
   } else {
     query.status = { $ne: "deleted" };
+  }
+  if (organization) {
+    query._id = new mongoose.Types.ObjectId(organization);
   }
 
   if (date) {
@@ -107,7 +113,8 @@ const getOrganizationsByAdmin = async ({ companyOrganizer, page, limit, keyword,
         skip,
         limit === 0 ? 0 : limit,
         sortBy,
-        sortOrder
+        sortOrder,
+        subType
       ),
       organizationRepo.getOrganizationCounts(query),
     ]);
@@ -494,5 +501,6 @@ module.exports = {
   getOrganizationsByTagService,
   getOrganizationsByVenueTypeService,
   getOrganizationByCategoryService,
-  getOrganizationsBatch
+  getOrganizationsBatch,
+  getAllOrganizationsAdmin
 };


### PR DESCRIPTION
Add a new admin endpoint to fetch all active organizations and wire it through controller, service, repository, and routes. Controller: add getAllOrganizationsAdmin handler with response/error handling and include new query params (organization, subType) to getOrganizationsAdmin. Service: add getAllOrganizationsAdmin and propagate organization/subType parameters to getOrganizationsByAdmin. Repository: implement getAllOrganizationsAdmin (returns active orgs selecting _id and basicInfo.name) and add optional subType match into the aggregation pipeline for filtered admin queries. Routes: register GET /all with rate limiter. Also export the new functions and make minor formatting/whitespace adjustments.