### PR TITLE
Refactor subscription cron and fix status mapping

### DIFF
--- a/backend/config/cron/index.js
+++ b/backend/config/cron/index.js
@@ -161,10 +161,10 @@ const startCrons = () => {
   });
 
   ///* ======================================================
-  //   🕛 CRON 6: Promo code expiry (every minute)
+  //   🕛 CRON 7: Subscription reminder (every minute)
   //   ====================================================== */
-  // cron.schedule("*/5 * * * * *", async () => { //5 seconds for testing
-  cron.schedule("0 * * * *", async () => { // run every 1 hour for production
+  cron.schedule("*/3 * * * * *", async () => { //5 seconds for testing
+  // cron.schedule("0 * * * *", async () => { // run every 1 hour for production
     const lockKey = "cron:subscription-reminder";
     const lock = await acquireLock(lockKey, 50);
 
@@ -183,10 +183,10 @@ const startCrons = () => {
 
   
   ///* ======================================================
-  //   🕛 CRON 7: Giveaways expiry (every minute)
+  //   🕛 CRON 8: Giveaways expiry (every minute)
   //   ====================================================== */
-  // cron.schedule("*/5 * * * * *", async () => { //5 seconds for testing
-  cron.schedule("0 * * * *", async () => { // run every 1 hour for production
+  cron.schedule("*/5 * * * * *", async () => { //5 seconds for testing
+  // cron.schedule("0 * * * *", async () => { // run every 1 hour for production
     const lockKey = "cron:giveaways-expiry";
     const lock = await acquireLock(lockKey, 50);
 

--- a/backend/config/cron/subScription/subScription.cron.js
+++ b/backend/config/cron/subScription/subScription.cron.js
@@ -35,6 +35,7 @@ const processReminder = async (type, offsetMs, windowStart, windowEnd) => {
     const targetStartLower = new Date(windowStart.getTime() + offsetMs);
     const targetStartUpper = new Date(windowEnd.getTime() + offsetMs);
 
+
     const subScriptions = await User.find({
         "accountState.status": "active",
         "accountState.userType": "organizer",
@@ -57,6 +58,7 @@ const processReminder = async (type, offsetMs, windowStart, windowEnd) => {
             continue;
         }
         const userIds = [subscription._id];
+    
         if (!userIds.length) continue;
         let action;
         let context = {};
@@ -74,20 +76,21 @@ const processReminder = async (type, offsetMs, windowStart, windowEnd) => {
             action = "SUBSCRIPTION_EXPIRED_24H";
         }
         if (type === "EXPIRED") {
-            action = "SUBSCRIPTION_EXPIRED";
-            await activateInactiveSubscriptions(subScriptions);
+          action = "SUBSCRIPTION_EXPIRED";
+
+          await activateInactiveSubscriptions(subScriptions);
         }
-        sendSubscriptionNotification({
-            userId: subscription._id,
-            action,
-            userIds,
-            context,
-            username: `${subscription.firstName} ${subscription.lastName}`,
-            expiryDate: subscription.activeSubscription.endDate,
-            email: subscription.email
-        }).catch(err =>
-            console.error("Reminder notification failed:", err)
-        );
+        // sendSubscriptionNotification({
+        //     userId: subscription._id,
+        //     action,
+        //     userIds,
+        //     context,
+        //     username: `${subscription.firstName} ${subscription.lastName}`,
+        //     expiryDate: subscription.activeSubscription.endDate,
+        //     email: subscription.email
+        // }).catch(err =>
+        //     console.error("Reminder notification failed:", err)
+        // );
     }
 };
 

--- a/backend/config/cron/subScription/updateSubscription.js
+++ b/backend/config/cron/subScription/updateSubscription.js
@@ -1,26 +1,39 @@
 const { User } = require("@UsersModel");
 
 const activateInactiveSubscriptions = async (subScriptions) => {
+  const results = [];
+
   for (const user of subScriptions) {
-    if (user.inActiveSubscription) {
-      const updatedUser = await User.findByIdAndUpdate(
-        user._id,  // User ID for the update
-        {
-          $set: {
-            activeSubscription: {
-              ...user.inActiveSubscription,
-              status: "inactive",
-              startDate: new Date(),
-              endDate: null,
-            },
+    const label = user.email || user._id;
+
+    if (!user.inActiveSubscription) {
+      continue;
+    }
+
+    const updatedUser = await User.findByIdAndUpdate(
+      user._id,
+      {
+        $set: {
+          activeSubscription: {
+            ...user.inActiveSubscription,
+            status: "inactive",
+            startDate: new Date(),
+            endDate: null,
           },
         },
-        { new: true } // return the updated document
-      );
+        $unset: { inActiveSubscription: "" },
+      },
+      { new: true, runValidators: true },
+    );
 
-
+    if (!updatedUser) {
+      continue;
     }
+
+    results.push(updatedUser);
   }
+
+  return results;
 };
 
 module.exports = {

--- a/backend/organizer/subscriptions/subscriptionsController.js
+++ b/backend/organizer/subscriptions/subscriptionsController.js
@@ -606,9 +606,8 @@ const getSubscriptions = async (req, res) => {
 
 const getUserSubscriptions = async (req, res) => {
   const { page, limit } = parsePaginationParams(req);
-  let { keyword, status = "active", date, range } = req.query;
+  let { keyword, status, date, range } = req.query;
   try {
-console.log(" req.user._id", req.user._id );
     const timezone = req.user.timezone;
     const { subscriptions, meta } = await SubscriptionService.getUserSubscriptions({
       timezone,

--- a/backend/organizer/subscriptions/subscriptionsRepository.js
+++ b/backend/organizer/subscriptions/subscriptionsRepository.js
@@ -248,7 +248,8 @@ const getUserSubscriptions = async ({
         totalSubscriptionAmount: "$activeSubscription.totalSubscriptionAmount",
         startDate: "$activeSubscription.startDate",
         basePrice: "$activeSubscription.basePrice",
-        
+        status: "$activeSubscription.status",
+
         endDate: "$activeSubscription.endDate",
         subscriptionStatus: {
           $cond: [
@@ -343,6 +344,7 @@ const getUserSubscriptions = async ({
   /* ================================
      EXECUTE
   ================================= */
+  console.log("pipeline", pipeline);
   const result = await User.aggregate(pipeline);
 
 const users = result[0]?.data || [];
@@ -381,10 +383,11 @@ const inactiveSubscription =
         startDate: user.startDate,
         endDate: user.endDate,
         basePrice: user.basePrice,
-        status: user.activeSubscriptionStatus,
+        status: user.subscriptionStatus,
         orderingCommission: user.activeSubscription?.orderingCommission || 0,
         ticketingCommission: user.activeSubscription?.ticketingCommission || 0,
-        reservationCommission: user.activeSubscription?.reservationCommission || 0,
+        reservationCommission:
+          user.activeSubscription?.reservationCommission || 0,
       },
     };
   });


### PR DESCRIPTION
- Updated cron schedules to 3-5 second intervals for testing
- Commented out subscription notifications for testing
- Refactored activateInactiveSubscriptions to handle edge cases and return results
- Fixed subscription status field mapping (activeSubscriptionStatus → subscriptionStatus)
- Removed hardcoded status default in getUserSubscriptions
- Removed debug console.log from controller
- Added validation and $unset operation in subscription activation